### PR TITLE
Please add this line to copy kvf_err_code.h in include/kvf

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,4 +39,5 @@ pkginclude_HEADERS = \
   include/kvf/kvf_api.h \
   include/kvf/kvf_list.h \
   include/kvf/kvf_type.h \
+  include/kvf/kvf_err_code.h \
   include/kvf/kvf.h


### PR DESCRIPTION
Or there must be a compilation bug when including from the installed directory.